### PR TITLE
Fix support for repeats

### DIFF
--- a/lib/create-video.js
+++ b/lib/create-video.js
@@ -119,37 +119,45 @@ function getKeyframes(mediaInfo) {
 		...element
 	}));
 
-	const keyframes = [...new Set(measures.map(({ page }) => page))].flatMap(page => {
-		const pageMeasures = measures.filter(measure => page === measure.page);
+	const systems = {};
 
-		return [...new Set(pageMeasures.map(({ y }) => y))].flatMap(position => {
-			const measures = pageMeasures.filter(({ y }) => y === position);
+	measures.forEach(measure => {
+		const key = `${measure.page}:${measure.y}`;
 
-			assert(measures.every(({ sy }) => sy === measures[0].sy));
+		if (!(key in systems)) {
+			systems[key] = [];
+		}
 
-			const x = Math.min(...measures.map(({ x }) => x));
-			const y = Math.min(...measures.map(({ y }) => y));
+		systems[key].push(measure);
+	});
 
-			const system = {
-				page,
-				x,
-				y,
-				sx: Math.max(...measures.map(({ x, sx }) => x + sx)) - x,
-				sy: Math.max(...measures.map(({ y, sy }) => y + sy)) - y
-			};
+	Object.values(systems).forEach(measures => {
+		assert(measures.every(({ sy }) => sy === measures[0].sy));
 
-			return measures.flatMap(({ start, end, x, sx }) => [
-				...spos
-					.filter(({ position }) => position >= start && position < end)
-					.map(({ position, element: { x } }) => ({ position, x, system })),
-				{
-					position: end,
-					x: x + sx,
-					system
-				}
-			]);
+		const x = Math.min(...measures.map(({ x }) => x));
+		const system = {
+			page: measures[0].page,
+			x,
+			y: measures[0].y,
+			sx: Math.max(...measures.map(({ x, sx }) => x + sx)) - x,
+			sy: measures[0].sy
+		};
+
+		measures.forEach(measure => {
+			measure.system = system;
 		});
 	});
+
+	const keyframes = measures.flatMap(({ start, end, x, sx, system }) => [
+		...spos
+			.filter(({ position }) => position >= start && position < end)
+			.map(({ position, element: { x } }) => ({ position, x, system })),
+		{
+			position: end,
+			x: x + sx,
+			system
+		}
+	]);
 
 	assert.strictEqual(keyframes.length, spos.length + mpos.length);
 	assert(keyframes.slice(1).every(({ position }, i) => keyframes[i].position <= position));


### PR DESCRIPTION
Fixes #5

#6 added a naive support for repeats. It was actually supposed to close #5 but I probably forgot to add a closing keyword. Which is good because the application still crashes when it encounters a repeat.

This PR fixes that hopefully for good.